### PR TITLE
Update latest stable tag version

### DIFF
--- a/src/Rocket.Chat-livechat/README.md
+++ b/src/Rocket.Chat-livechat/README.md
@@ -4,7 +4,7 @@ Donate link: http://rocket.chat
 Tags: rocket.chat, chat, livechat, support, sales
 Requires at least: 3.0.1
 Tested up to: 5.3
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +73,9 @@ No, this plugin is only for support messaging, i.e. customer contacts sales with
 3. Offline form for sending messages
 
 == Changelog ==
+
+= 1.0.3 =
+* Remove '1.0.0' string from Livechat public path URL
 
 = 1.0.2 =
 * Update LiveChat script

--- a/src/Rocket.Chat-livechat/README.txt
+++ b/src/Rocket.Chat-livechat/README.txt
@@ -4,7 +4,7 @@ Donate link: http://rocket.chat
 Tags: rocket.chat, chat, livechat, support, sales
 Requires at least: 3.0.1
 Tested up to: 5.3
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +73,9 @@ No, this plugin is only for support messaging, i.e. customer contacts sales with
 3. Offline form for sending messages
 
 == Changelog ==
+
+= 1.0.3 =
+* Remove '1.0.0' string from Livechat public path URL
 
 = 1.0.2 =
 * Update LiveChat script

--- a/src/Rocket.Chat-livechat/includes/class-rocketchat-livechat.php
+++ b/src/Rocket.Chat-livechat/includes/class-rocketchat-livechat.php
@@ -69,7 +69,7 @@ class Rocketchat_Livechat {
 	public function __construct() {
 
 		$this->plugin_name = 'rocketchat-livechat';
-		$this->version = '1.0.2';
+		$this->version = '1.0.3';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/src/Rocket.Chat-livechat/rocketchat-livechat.php
+++ b/src/Rocket.Chat-livechat/rocketchat-livechat.php
@@ -2,14 +2,14 @@
 /**
  *
  * @link              http://rocket.chat
- * @since             1.0.2
+ * @since             1.0.3
  * @package           Rocketchat_Livechat
  *
  * @wordpress-plugin
  * Plugin Name:       Rocket.Chat LiveChat
  * Plugin URI:        http://rocket.chat
  * Description:       This is a short description of what the plugin does. It's displayed in the WordPress admin area.
- * Version:           1.0.2
+ * Version:           1.0.3
  * Author:            Marko Banušić
  * Author URI:        http://nezn.am
  * License:           GPL-2.0+


### PR DESCRIPTION
When we submitted/merged the latest [pull request](https://github.com/RocketChat/WordPressPlugin/pull/22) the changelog has not been updated.

This PR updates the latest stable tag version to `1.0.3`.
