### PR TITLE
Added initial setup notice on plugin initial activation, mentioned WordPress 5.4.1 and PHP support

### DIFF
--- a/src/Rocket.Chat-livechat/README.md
+++ b/src/Rocket.Chat-livechat/README.md
@@ -4,7 +4,7 @@ Donate link: http://rocket.chat
 Tags: rocket.chat, chat, livechat, support, sales
 Requires at least: 3.0.1
 Tested up to: 5.3
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +73,9 @@ No, this plugin is only for support messaging, i.e. customer contacts sales with
 3. Offline form for sending messages
 
 == Changelog ==
+
+= 1.0.3 =
+* Added setup notice on plugin activation
 
 = 1.0.2 =
 * Update LiveChat script

--- a/src/Rocket.Chat-livechat/README.txt
+++ b/src/Rocket.Chat-livechat/README.txt
@@ -3,8 +3,9 @@ Contributors: rocketchat, mbanusic, junglewp
 Donate link: http://rocket.chat
 Tags: rocket.chat, chat, livechat, support, sales
 Requires at least: 3.0.1
-Tested up to: 5.3
-Stable tag: 1.0.2
+Tested up to: 5.4.1
+Requires PHP: 7.2
+Stable tag: 1.0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +74,9 @@ No, this plugin is only for support messaging, i.e. customer contacts sales with
 3. Offline form for sending messages
 
 == Changelog ==
+
+= 1.0.3 =
+* Added setup notice on plugin activation
 
 = 1.0.2 =
 * Update LiveChat script

--- a/src/Rocket.Chat-livechat/admin/class-rocketchat-livechat-admin.php
+++ b/src/Rocket.Chat-livechat/admin/class-rocketchat-livechat-admin.php
@@ -165,4 +165,21 @@ class Rocketchat_Livechat_Admin {
 				class="description"><?php echo esc_html( $args['desc'] ); ?></p><?php
 		}
 	}
+
+	public function rocketchat_livechat_admin_notice_url_setup(){
+
+		/* Delete transient, only if the Rocket.chat URL is present. */
+			  delete_transient( 'rocketchat-admin-notice-livechat-url' );
+  
+	    /* Check transient, if available display notice */
+			if( get_transient( 'rocketchat-admin-notice-livechat-url' )  || empty(get_option('rocketchat-livechat-url')) ){
+				 ?>
+				<div class="notice notice-info is-dismissible">
+				<p>Thank you for using Rocket.Chat Livechat! <strong><a href="<?php echo get_admin_url() ;?>options-general.php?page=Rocket.Chat-livechat/admin/class-rocketchat-livechat-admin.php">Please activate your Rocket.Chat URL</a></strong>.</p>
+  
+				</div>
+				<?php
+		 }
+	 }
+
 }

--- a/src/Rocket.Chat-livechat/includes/class-rocketchat-livechat-activator.php
+++ b/src/Rocket.Chat-livechat/includes/class-rocketchat-livechat-activator.php
@@ -24,6 +24,11 @@ class Rocketchat_Livechat_Activator {
 
 	public static function activate() {
 		add_option( 'rocketchat-livechat-url' );
-	}
 
+	/**
+	 * Add transient upon activation, we want to display a notice during activation
+	 * so that the user can setup their
+	 */
+	    set_transient( 'rocketchat-admin-notice-livechat-url', 'no_url' );
+	}
 }

--- a/src/Rocket.Chat-livechat/includes/class-rocketchat-livechat.php
+++ b/src/Rocket.Chat-livechat/includes/class-rocketchat-livechat.php
@@ -69,7 +69,7 @@ class Rocketchat_Livechat {
 	public function __construct() {
 
 		$this->plugin_name = 'rocketchat-livechat';
-		$this->version = '1.0.2';
+		$this->version = '1.0.3';
 
 		$this->load_dependencies();
 		$this->set_locale();
@@ -153,6 +153,7 @@ class Rocketchat_Livechat {
 
 		$this->loader->add_action( 'admin_menu', $plugin_admin, 'menu' );
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
+		$this->loader->add_action( 'admin_notices', $plugin_admin, 'rocketchat_livechat_admin_notice_url_setup' );
 
 	}
 

--- a/src/Rocket.Chat-livechat/rocketchat-livechat.php
+++ b/src/Rocket.Chat-livechat/rocketchat-livechat.php
@@ -2,14 +2,14 @@
 /**
  *
  * @link              http://rocket.chat
- * @since             1.0.2
+ * @since             1.0.3
  * @package           Rocketchat_Livechat
  *
  * @wordpress-plugin
  * Plugin Name:       Rocket.Chat LiveChat
  * Plugin URI:        http://rocket.chat
  * Description:       This is a short description of what the plugin does. It's displayed in the WordPress admin area.
- * Version:           1.0.2
+ * Version:           1.0.3
  * Author:            Marko Banušić
  * Author URI:        http://nezn.am
  * License:           GPL-2.0+


### PR DESCRIPTION
@engelgabriel Bumped to 1.0.3, Added setup notice on plugin initial activation, mentioned WordPress 5.4.1 and PHP compatibility to avoid WordPress 5.3+ compatibility alerts.